### PR TITLE
provide make based compilation for the nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,27 +5,35 @@
   };
 
   outputs = { nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in rec {
-      devShell = pkgs.mkShell {
-        inputsFrom = [ packages.cano ];
-      };
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
 
-      packages = rec {
-        default = cano;
-        cano = pkgs.stdenv.mkDerivation {
-          name = "cano";
-          src = ./.;
+        hardeningDisable = [ "format" "fortify" ];
+      in
+      rec {
+        devShell = pkgs.mkShell {
+          inherit hardeningDisable;
 
-          buildInputs = with pkgs; [ gnumake ncurses ];
-          hardeningDisable = [ "format" "fortify" ];
-
-          installPhase = ''
-            mkdir -p $out/bin
-            cp build/cano $out/bin
-          '';
+          inputsFrom = [ packages.cano ];
         };
-      };
-    });
+
+        formatter = pkgs.nixpkgs-fmt;
+
+        packages = rec {
+          default = cano;
+          cano = pkgs.stdenv.mkDerivation rec {
+            inherit hardeningDisable;
+
+            name = "cano";
+            src = ./.;
+
+            buildInputs = with pkgs; [ gnumake ncurses ];
+            installPhase = ''
+              mkdir -p $out/bin
+              cp build/${name} $out/bin
+            '';
+          };
+        };
+      });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -14,26 +14,16 @@
 
       packages = rec {
         default = cano;
-        cano = pkgs.stdenv.mkDerivation rec {
+        cano = pkgs.stdenv.mkDerivation {
           name = "cano";
           src = ./.;
 
-          buildInputs = with pkgs; [ ncurses ];
+          buildInputs = with pkgs; [ gnumake ncurses ];
           hardeningDisable = [ "format" "fortify" ];
-
-          buildPhase = ''
-            runHook preBuild
-
-            ${pkgs.stdenv.cc}/bin/cc -o cano src/main.c \
-              -Wall -Wextra -pedantic \
-              -lncurses -lm
-
-            runHook postBuild
-          '';
 
           installPhase = ''
             mkdir -p $out/bin
-            cp ${name} $out/bin
+            cp build/cano $out/bin
           '';
         };
       };


### PR DESCRIPTION
Change done on [8c258c](https://github.com/CobbCoding1/Cano/commit/8c258c497fa981d4e0f21ec0503f166caf3f9382) allows for direct make build.
Update `flake.nix` to reflect the change, and improve smaller aspect (format & shell hardening)