### PR TITLE
Debian/Ubuntu install

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,10 @@ nix run github:CobbCoding1/Cano
 
 A flake has been provided within the repository, including the package and a devShell.
 
-# Debian/Ubuntu
+## Debian/Ubuntu
+
+You may build from source and install cano directly to `/usr/local/bin`. You must have a basic C compiler installed, as well as the ncurses library (install shown below).
+
 ```sh
 sudo apt install libncurses-dev
 git clone https://github.com/CobbCoding1/Cano && cd Cano

--- a/README.md
+++ b/README.md
@@ -182,4 +182,5 @@ A flake has been provided within the repository, including the package and a dev
 sudo apt install libncurses-dev
 git clone https://github.com/CobbCoding1/Cano && cd Cano
 make
+sudo ./debian-install.sh
 ```

--- a/debian-install.sh
+++ b/debian-install.sh
@@ -1,0 +1,7 @@
+
+if [ -d ./build ]; then	
+	cp build/cano /usr/local/bin/
+else
+	echo "Please build Cano before installing."
+fi
+


### PR DESCRIPTION
Along with the installation instructions for Debian and Ubuntu, there is also a shell script which will automatically install the binary executable to /usr/local/bin which should be on the user's path. If one wishes, they can change the location of this if they want it elsewhere.