### PR TITLE
make PKGBUILD more generic by using make install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 main
 out.txt
 build/
+errors.cano

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: CobbCoding 
 pkgname=cano-git
 _pkgname=cano
-pkgver=r93.8efde9f
+pkgver=r309.0a6fb09
 pkgrel=1
 pkgdesc="Terminal-based modal text editor"
 arch=('x86_64')
@@ -23,7 +23,7 @@ build() {
 }
 
 package() {
-    cd "$_pkgname" 
-    install -Dm755 ./build/"$_pkgname" "$pkgdir/usr/bin/$_pkgname"
+    cd "$_pkgname"
+    make install
     install -Dm755 ./README.md "$pkgdir/usr/share/doc/$_pkgname"
 }

--- a/src/defs.h
+++ b/src/defs.h
@@ -261,10 +261,12 @@ typedef struct State {
 
     Sized_Str clipboard;
 
-    Files* files;
+    Files *files;
     bool is_exploring;
     size_t explore_cursor;
-    Buffer* buffer;
+    Buffer *buffer;
+    char *config_filename;
+    char *syntax_filename;
 
     // window sizes
     int grow;


### PR DESCRIPTION
This change makes it possible to change install instructions (via. the Makefile) without messing up the AUR package (since it now relies on `make install`).

TODO:
- fix the flake.nix so that help pages work on Nix systems