### PR TITLE
PKGBUILD & filemanager fixes

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: CobbCoding 
 pkgname=cano-git
 _pkgname=cano
-pkgver=r93.8efde9f
+pkgver=r309.0a6fb09
 pkgrel=1
 pkgdesc="Terminal-based modal text editor"
 arch=('x86_64')
@@ -23,7 +23,7 @@ build() {
 }
 
 package() {
-    cd "$_pkgname" 
-    install -Dm755 ./build/"$_pkgname" "$pkgdir/usr/bin/$_pkgname"
+    cd "$_pkgname"
+    make install
     install -Dm755 ./README.md "$pkgdir/usr/share/doc/$_pkgname"
 }


### PR DESCRIPTION
This PR makes it possible to change install instructions (via. the Makefile) without messing up the AUR package (since it now relies on make install).
It is also a fix for the issue #45.

TODO:
- fix the flake.nix so that help pages work on Nix systems