### PR TITLE
open help-pages inside of cano

### DIFF
--- a/docs/cano.1
+++ b/docs/cano.1
@@ -22,7 +22,7 @@ uses the specified config-file instead of the default config.
 
 .TP
 .BR \-\-help " [\fIhelp-page\fR]
-prints the specified help page or the "general" page if no page was specified.
+opens the specified help-page or the "general" page if no page was specified.
 
 .SH EDITING
 Editing a file is fairly easy; you start the editor and start typing the letters that you want.


### PR DESCRIPTION
Cano will now open the help page specified instead of printing it to stdout.