### PR TITLE
debian/ubuntu fix

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,5 +11,5 @@ cano_SOURCES = src/colors.h \
 			   src/lex.c \
 			   src/main.c \
 			   src/view.c
-cano_CPPFLAGS = @NCURSES_CFLAGS@
-cano_LDFLAGS = @NCURSES_LIBS@ -lm -lpthread
+cano_CFLAGS = @NCURSES_CFLAGS@
+cano_LDADD = @NCURSES_LIBS@ -lm -lpthread

--- a/README.md
+++ b/README.md
@@ -186,14 +186,15 @@ Cano's build system recently changed, Nix installation is not supported for now.
 
 ## Debian/Ubuntu
 
-You may build from source and install cano directly to `/usr/local/bin`. You must have a basic C compiler, autotools and the ncurses library installed (install shown below).
+You may build from source and install cano directly to `/usr/local/bin`. You must have a basic C compiler, autotools, pkg-config and the ncurses library installed (install shown below).
 
 ```sh
-sudo apt install libncurses-dev autotools-dev
+sudo apt install gcc autoconf automake libtool pkg-config make libncurses-dev
 git clone https://github.com/CobbCoding1/Cano && cd Cano
 chmod +x autogen.sh && ./autogen.sh
-make -C build
-sudo make -C build install
+cd build
+make
+sudo make install
 ```
 
 ## Canoon (Beta)


### PR DESCRIPTION
I've tested building, running and installing cano on debian (6.1.90-1). Turns out the gcc packaged for debian cares about the order of -l flags while the gcc packaged for arch does not (maybe because arch is using the latest gcc version). Anyways, after changing LDFLAGS to LDADD in Makefile.am, the linker flags will be added to the end of the gcc command (LDFLAGS added them in the front).
Cano is compiling for debian (and probably ubuntu, not tested though) :tada: 