### PR TITLE
add manpage to Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,3 +13,5 @@ cano_SOURCES = src/colors.h \
 			   src/view.c
 cano_CFLAGS = @NCURSES_CFLAGS@
 cano_LDADD = @NCURSES_LIBS@ -lm -lpthread
+
+man1_MANS = docs/cano.1


### PR DESCRIPTION
Cano's manpage will now be installed when running 'make install'